### PR TITLE
Feat: implementation of includes (#118)

### DIFF
--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/CreatingResourcesTests.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/CreatingResourcesTests.cs
@@ -112,5 +112,34 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests
                 }
             }
         }
+
+
+        [TestMethod]
+        [DeploymentItem(@"Data\Comment.csv", @"Data")]
+        [DeploymentItem(@"Data\Post.csv", @"Data")]
+        [DeploymentItem(@"Data\PostTagLink.csv", @"Data")]
+        [DeploymentItem(@"Data\Tag.csv", @"Data")]
+        [DeploymentItem(@"Data\User.csv", @"Data")]
+        public async Task Post_with_empty_id_and_include()
+        {
+            using (var effortConnection = GetEffortConnection())
+            {
+                var response = await SubmitPost(effortConnection, "posts?include=author", @"Fixtures\CreatingResources\Requests\Post_with_empty_id_Request.json");
+
+                await AssertResponseContent(response, @"Fixtures\CreatingResources\Responses\Post_with_empty_id_and_include_author_Response.json", HttpStatusCode.OK);
+
+                using (var dbContext = new TestDbContext(effortConnection, false))
+                {
+                    var allPosts = dbContext.Posts.ToArray();
+                    allPosts.Length.Should().Be(5);
+                    var actualPost = allPosts.First(t => t.Id == "230");
+                    actualPost.Id.Should().Be("230");
+                    actualPost.Title.Should().Be("New post");
+                    actualPost.Content.Should().Be("The server generated my ID");
+                    actualPost.Created.Should().Be(new DateTimeOffset(2015, 04, 13, 12, 09, 0, new TimeSpan(0, 3, 0, 0)));
+                    actualPost.AuthorId.Should().Be("401");
+                }
+            }
+        }
     }
 }

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/FetchingResourcesTests.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/FetchingResourcesTests.cs
@@ -99,6 +99,23 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests
             }
         }
 
+
+        [TestMethod]
+        [DeploymentItem(@"Data\Comment.csv", @"Data")]
+        [DeploymentItem(@"Data\Post.csv", @"Data")]
+        [DeploymentItem(@"Data\PostTagLink.csv", @"Data")]
+        [DeploymentItem(@"Data\Tag.csv", @"Data")]
+        [DeploymentItem(@"Data\User.csv", @"Data")]
+        public async Task Get_related_to_many_included()
+        {
+            using (var effortConnection = GetEffortConnection())
+            {
+                var response = await SubmitGet(effortConnection, "posts/201/comments?include=author");
+
+                await AssertResponseContent(response, @"Fixtures\FetchingResources\Get_related_to_many_include_response.json", HttpStatusCode.OK);
+            }
+        }
+
         [TestMethod]
         [DeploymentItem(@"Data\Comment.csv", @"Data")]
         [DeploymentItem(@"Data\Post.csv", @"Data")]
@@ -112,6 +129,23 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests
                 var response = await SubmitGet(effortConnection, "posts/201/author");
 
                 await AssertResponseContent(response, @"Fixtures\FetchingResources\Get_related_to_one_response.json", HttpStatusCode.OK);
+            }
+        }
+
+
+        [TestMethod]
+        [DeploymentItem(@"Data\Comment.csv", @"Data")]
+        [DeploymentItem(@"Data\Post.csv", @"Data")]
+        [DeploymentItem(@"Data\PostTagLink.csv", @"Data")]
+        [DeploymentItem(@"Data\Tag.csv", @"Data")]
+        [DeploymentItem(@"Data\User.csv", @"Data")]
+        public async Task Get_included_to_one()
+        {
+            using (var effortConnection = GetEffortConnection())
+            {
+                var response = await SubmitGet(effortConnection, "posts/201?include=author");
+
+                await AssertResponseContent(response, @"Fixtures\FetchingResources\Get_included_to_one_response.json", HttpStatusCode.OK);
             }
         }
 

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/CreatingResources/Responses/Post_with_empty_id_and_include_author_Response.json
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/CreatingResources/Responses/Post_with_empty_id_and_include_author_Response.json
@@ -1,0 +1,65 @@
+﻿{
+  "data": {
+    "type": "posts",
+    "id": "230",
+    "attributes": {
+      "content": "The server generated my ID",
+      "created": "2015-04-13T09:09:00.0000000+00:00",
+      "title": "New post"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "https://www.example.com/posts/230/relationships/author",
+          "related": "https://www.example.com/posts/230/author"
+        },
+        "data": {
+          "type": "users",
+          "id": "401"
+        }
+      },
+      "comments": {
+        "links": {
+          "self": "https://www.example.com/posts/230/relationships/comments",
+          "related": "https://www.example.com/posts/230/comments"
+        }
+      },
+      "tags": {
+        "links": {
+          "self": "https://www.example.com/posts/230/relationships/tags",
+          "related": "https://www.example.com/posts/230/tags"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "users",
+      "id": "401",
+      "attributes": {
+        "first-name": "Alice",
+        "last-name": "Smith"
+      },
+      "relationships": {
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/comments",
+            "related": "https://www.example.com/users/401/comments"
+          }
+        },
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/posts",
+            "related": "https://www.example.com/users/401/posts"
+          }
+        },
+        "user-groups": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/user-groups",
+            "related": "https://www.example.com/users/401/user-groups"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_included_to_one_response.json
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_included_to_one_response.json
@@ -1,0 +1,65 @@
+﻿{
+  "data": {
+    "type": "posts",
+    "id": "201",
+    "attributes": {
+      "content": "Post 1 content",
+      "created": "2015-01-31T14:00:00.0000000+00:00",
+      "title": "Post 1"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "https://www.example.com/posts/201/relationships/author",
+          "related": "https://www.example.com/posts/201/author"
+        },
+        "data": {
+          "type": "users",
+          "id": "401"
+        }
+      },
+      "comments": {
+        "links": {
+          "self": "https://www.example.com/posts/201/relationships/comments",
+          "related": "https://www.example.com/posts/201/comments"
+        }
+      },
+      "tags": {
+        "links": {
+          "self": "https://www.example.com/posts/201/relationships/tags",
+          "related": "https://www.example.com/posts/201/tags"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "users",
+      "id": "401",
+      "attributes": {
+        "first-name": "Alice",
+        "last-name": "Smith"
+      },
+      "relationships": {
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/comments",
+            "related": "https://www.example.com/users/401/comments"
+          }
+        },
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/posts",
+            "related": "https://www.example.com/users/401/posts"
+          }
+        },
+        "user-groups": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/user-groups",
+            "related": "https://www.example.com/users/401/user-groups"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_related_to_many_include_response.json
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/FetchingResources/Get_related_to_many_include_response.json
@@ -1,0 +1,140 @@
+﻿{
+  "data": [
+    {
+      "type": "comments",
+      "id": "101",
+      "attributes": {
+        "created": "2015-01-31T14:30:00.0000000+00:00",
+        "text": "Comment 1"
+      },
+      "relationships": {
+        "author": {
+          "links": {
+            "self": "https://www.example.com/comments/101/relationships/author",
+            "related": "https://www.example.com/comments/101/author"
+          },
+          "data": {
+            "type": "users",
+            "id": "403"
+          }
+        },
+        "post": {
+          "links": {
+            "self": "https://www.example.com/comments/101/relationships/post",
+            "related": "https://www.example.com/comments/101/post"
+          }
+        }
+      }
+    },
+    {
+      "type": "comments",
+      "id": "102",
+      "attributes": {
+        "created": "2015-01-31T14:35:00.0000000+00:00",
+        "text": "Comment 2"
+      },
+      "relationships": {
+        "author": {
+          "links": {
+            "self": "https://www.example.com/comments/102/relationships/author",
+            "related": "https://www.example.com/comments/102/author"
+          },
+          "data": {
+            "type": "users",
+            "id": "402"
+          }
+        },
+        "post": {
+          "links": {
+            "self": "https://www.example.com/comments/102/relationships/post",
+            "related": "https://www.example.com/comments/102/post"
+          }
+        }
+      }
+    },
+    {
+      "type": "comments",
+      "id": "103",
+      "attributes": {
+        "created": "2015-01-31T14:41:00.0000000+00:00",
+        "text": "Comment 3"
+      },
+      "relationships": {
+        "author": {
+          "links": {
+            "self": "https://www.example.com/comments/103/relationships/author",
+            "related": "https://www.example.com/comments/103/author"
+          },
+          "data": {
+            "type": "users",
+            "id": "403"
+          }
+        },
+        "post": {
+          "links": {
+            "self": "https://www.example.com/comments/103/relationships/post",
+            "related": "https://www.example.com/comments/103/post"
+          }
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "type": "users",
+      "id": "403",
+      "attributes": {
+        "first-name": "Charlie",
+        "last-name": "Michaels"
+      },
+      "relationships": {
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/users/403/relationships/comments",
+            "related": "https://www.example.com/users/403/comments"
+          }
+        },
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/users/403/relationships/posts",
+            "related": "https://www.example.com/users/403/posts"
+          }
+        },
+        "user-groups": {
+          "links": {
+            "self": "https://www.example.com/users/403/relationships/user-groups",
+            "related": "https://www.example.com/users/403/user-groups"
+          }
+        }
+      }
+    },
+    {
+      "type": "users",
+      "id": "402",
+      "attributes": {
+        "first-name": "Bob",
+        "last-name": "Jones"
+      },
+      "relationships": {
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/users/402/relationships/comments",
+            "related": "https://www.example.com/users/402/comments"
+          }
+        },
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/users/402/relationships/posts",
+            "related": "https://www.example.com/users/402/posts"
+          }
+        },
+        "user-groups": {
+          "links": {
+            "self": "https://www.example.com/users/402/relationships/user-groups",
+            "related": "https://www.example.com/users/402/user-groups"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/UpdatingResources/Responses/PatchWithAttributeUpdateWithIncludeResponse.json
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/Fixtures/UpdatingResources/Responses/PatchWithAttributeUpdateWithIncludeResponse.json
@@ -1,0 +1,65 @@
+﻿{
+  "data": {
+    "type": "posts",
+    "id": "202",
+    "attributes": {
+      "content": "Post 2 content",
+      "created": "2015-02-05T08:10:00.0000000+00:00",
+      "title": "New post title"
+    },
+    "relationships": {
+      "author": {
+        "links": {
+          "self": "https://www.example.com/posts/202/relationships/author",
+          "related": "https://www.example.com/posts/202/author"
+        },
+        "data": {
+          "type": "users",
+          "id": "401"
+        }
+      },
+      "comments": {
+        "links": {
+          "self": "https://www.example.com/posts/202/relationships/comments",
+          "related": "https://www.example.com/posts/202/comments"
+        }
+      },
+      "tags": {
+        "links": {
+          "self": "https://www.example.com/posts/202/relationships/tags",
+          "related": "https://www.example.com/posts/202/tags"
+        }
+      }
+    }
+  },
+  "included": [
+    {
+      "type": "users",
+      "id": "401",
+      "attributes": {
+        "first-name": "Alice",
+        "last-name": "Smith"
+      },
+      "relationships": {
+        "comments": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/comments",
+            "related": "https://www.example.com/users/401/comments"
+          }
+        },
+        "posts": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/posts",
+            "related": "https://www.example.com/users/401/posts"
+          }
+        },
+        "user-groups": {
+          "links": {
+            "self": "https://www.example.com/users/401/relationships/user-groups",
+            "related": "https://www.example.com/users/401/user-groups"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests.csproj
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.Tests.csproj
@@ -271,6 +271,10 @@
     <EmbeddedResource Include="Fixtures\UpdatingResources\Responses\PatchWithAttributeUpdateResponseID.json" />
     <EmbeddedResource Include="Fixtures\UpdatingResources\Requests\PatchWithAttributeUpdateRequestLongId.json" />
     <EmbeddedResource Include="Fixtures\UpdatingResources\Responses\PatchWithAttributeUpdateResponseLongId.json" />
+    <EmbeddedResource Include="Fixtures\FetchingResources\Get_included_to_one_response.json" />
+    <EmbeddedResource Include="Fixtures\FetchingResources\Get_related_to_many_include_response.json" />
+    <EmbeddedResource Include="Fixtures\CreatingResources\Responses\Post_with_empty_id_and_include_author_Response.json" />
+    <EmbeddedResource Include="Fixtures\UpdatingResources\Responses\PatchWithAttributeUpdateWithIncludeResponse.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <Choose>

--- a/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipOfficersRelatedResourceMaterializer.cs
+++ b/JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp/DocumentMaterializers/StarshipOfficersRelatedResourceMaterializer.cs
@@ -17,8 +17,9 @@ namespace JSONAPI.AcceptanceTests.EntityFrameworkTestWebApp.DocumentMaterializer
         public StarshipOfficersRelatedResourceMaterializer(ResourceTypeRelationship relationship, DbContext dbContext,
             IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder,
             ISortExpressionExtractor sortExpressionExtractor,
+            IIncludeExpressionExtractor includeExpressionExtractor,
             IResourceTypeRegistration primaryTypeRegistration)
-            : base(relationship, dbContext, queryableResourceCollectionDocumentBuilder, sortExpressionExtractor, primaryTypeRegistration)
+            : base(relationship, dbContext, queryableResourceCollectionDocumentBuilder, sortExpressionExtractor, includeExpressionExtractor, primaryTypeRegistration)
         {
             _dbContext = dbContext;
         }

--- a/JSONAPI.Autofac/JsonApiAutofacModule.cs
+++ b/JSONAPI.Autofac/JsonApiAutofacModule.cs
@@ -166,6 +166,7 @@ namespace JSONAPI.Autofac
 
             // Misc
             builder.RegisterType<DefaultSortExpressionExtractor>().As<ISortExpressionExtractor>().SingleInstance();
+            builder.RegisterType<DefaultIncludeExpressionExtractor>().As<IIncludeExpressionExtractor>().SingleInstance();
         }
     }
 }

--- a/JSONAPI.Tests/Documents/Builders/FallbackDocumentBuilderTests.cs
+++ b/JSONAPI.Tests/Documents/Builders/FallbackDocumentBuilderTests.cs
@@ -30,9 +30,10 @@ namespace JSONAPI.Tests.Documents.Builders
             var objectContent = new Fruit { Id = "984", Name = "Kiwi" };
 
             var mockDocument = new Mock<ISingleResourceDocument>(MockBehavior.Strict);
+            var includePathExpression = new string[] {};
 
             var singleResourceDocumentBuilder = new Mock<ISingleResourceDocumentBuilder>(MockBehavior.Strict);
-            singleResourceDocumentBuilder.Setup(b => b.BuildDocument(objectContent, It.IsAny<string>(), null, null, null)).Returns(mockDocument.Object);
+            singleResourceDocumentBuilder.Setup(b => b.BuildDocument(objectContent, It.IsAny<string>(), includePathExpression, null, null)).Returns(mockDocument.Object);
 
             var mockQueryableDocumentBuilder = new Mock<IQueryableResourceCollectionDocumentBuilder>(MockBehavior.Strict);
             var mockResourceCollectionDocumentBuilder = new Mock<IResourceCollectionDocumentBuilder>(MockBehavior.Strict);
@@ -44,11 +45,14 @@ namespace JSONAPI.Tests.Documents.Builders
             mockBaseUrlService.Setup(s => s.GetBaseUrl(request)).Returns("https://www.example.com");
 
             var mockSortExpressionExtractor = new Mock<ISortExpressionExtractor>(MockBehavior.Strict);
-            mockSortExpressionExtractor.Setup(e => e.ExtractSortExpressions(request)).Returns(new [] { "id "});
+            mockSortExpressionExtractor.Setup(e => e.ExtractSortExpressions(request)).Returns(new[] { "id " });
+
+            var mockIncludeExpressionExtractor = new Mock<IIncludeExpressionExtractor>(MockBehavior.Strict);
+            mockIncludeExpressionExtractor.Setup(e => e.ExtractIncludeExpressions(request)).Returns(includePathExpression);
 
             // Act
             var fallbackDocumentBuilder = new FallbackDocumentBuilder(singleResourceDocumentBuilder.Object,
-                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockBaseUrlService.Object);
+                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockIncludeExpressionExtractor.Object, mockBaseUrlService.Object);
             var resultDocument = await fallbackDocumentBuilder.BuildDocument(objectContent, request, cancellationTokenSource.Token);
 
             // Assert
@@ -75,12 +79,14 @@ namespace JSONAPI.Tests.Documents.Builders
             mockBaseUrlService.Setup(s => s.GetBaseUrl(request)).Returns("https://www.example.com/");
 
             var sortExpressions = new[] { "id" };
+
+            var includeExpressions = new string[] { };
             
             var cancellationTokenSource = new CancellationTokenSource();
 
             var mockQueryableDocumentBuilder = new Mock<IQueryableResourceCollectionDocumentBuilder>(MockBehavior.Strict);
             mockQueryableDocumentBuilder
-                .Setup(b => b.BuildDocument(items, request, sortExpressions, cancellationTokenSource.Token, null))
+                .Setup(b => b.BuildDocument(items, request, sortExpressions, cancellationTokenSource.Token, includeExpressions))
                 .Returns(Task.FromResult(mockDocument.Object));
 
             var mockResourceCollectionDocumentBuilder = new Mock<IResourceCollectionDocumentBuilder>(MockBehavior.Strict);
@@ -88,9 +94,12 @@ namespace JSONAPI.Tests.Documents.Builders
             var mockSortExpressionExtractor = new Mock<ISortExpressionExtractor>(MockBehavior.Strict);
             mockSortExpressionExtractor.Setup(e => e.ExtractSortExpressions(request)).Returns(sortExpressions);
 
+            var mockIncludeExpressionExtractor = new Mock<IIncludeExpressionExtractor>(MockBehavior.Strict);
+            mockIncludeExpressionExtractor.Setup(e => e.ExtractIncludeExpressions(request)).Returns(includeExpressions);
+
             // Act
             var fallbackDocumentBuilder = new FallbackDocumentBuilder(singleResourceDocumentBuilder.Object,
-                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockBaseUrlService.Object);
+                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockIncludeExpressionExtractor.Object, mockBaseUrlService.Object);
             var resultDocument = await fallbackDocumentBuilder.BuildDocument(items, request, cancellationTokenSource.Token);
 
             // Assert
@@ -127,9 +136,12 @@ namespace JSONAPI.Tests.Documents.Builders
             var mockSortExpressionExtractor = new Mock<ISortExpressionExtractor>(MockBehavior.Strict);
             mockSortExpressionExtractor.Setup(e => e.ExtractSortExpressions(request)).Returns(new[] { "id " });
 
+            var mockIncludeExpressionExtractor = new Mock<IIncludeExpressionExtractor>(MockBehavior.Strict);
+            mockIncludeExpressionExtractor.Setup(e => e.ExtractIncludeExpressions(request)).Returns(new string[] { });
+
             // Act
             var fallbackDocumentBuilder = new FallbackDocumentBuilder(singleResourceDocumentBuilder.Object,
-                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockBaseUrlService.Object);
+                mockQueryableDocumentBuilder.Object, mockResourceCollectionDocumentBuilder.Object, mockSortExpressionExtractor.Object, mockIncludeExpressionExtractor.Object, mockBaseUrlService.Object);
             var resultDocument = await fallbackDocumentBuilder.BuildDocument(items, request, cancellationTokenSource.Token);
 
             // Assert

--- a/JSONAPI.Tests/Http/DefaultIncludeExpressionExtractorTests.cs
+++ b/JSONAPI.Tests/Http/DefaultIncludeExpressionExtractorTests.cs
@@ -1,0 +1,57 @@
+﻿using System.Net.Http;
+using FluentAssertions;
+using JSONAPI.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace JSONAPI.Tests.Http
+{
+    [TestClass]
+    public class DefaultIncludeExpressionExtractorTests
+    {
+        [TestMethod]
+        public void ExtractsSingleIncludeExpressionFromUri()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies?include=boss";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultIncludeExpressionExtractor();
+            var inclExpressions = extractor.ExtractIncludeExpressions(request);
+
+            // Assert
+            inclExpressions.Should().BeEquivalentTo("boss");
+        }
+
+
+        [TestMethod]
+        public void ExtractsMultipleIncludeExpressionsFromUri()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies?include=boss,office-address";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultIncludeExpressionExtractor();
+            var inclExpressions = extractor.ExtractIncludeExpressions(request);
+
+            // Assert
+            inclExpressions.Should().BeEquivalentTo("boss", "office-address");
+        }
+
+        [TestMethod]
+        public void ExtractsNothingWhenThereIsNoIncludeParam()
+        {
+            // Arrange
+            const string uri = "http://api.example.com/dummies";
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            // Act
+            var extractor = new DefaultIncludeExpressionExtractor();
+            var inclExpression = extractor.ExtractIncludeExpressions(request);
+
+            // Assert
+            inclExpression.Length.Should().Be(0);
+        }
+    }
+}

--- a/JSONAPI.Tests/JSONAPI.Tests.csproj
+++ b/JSONAPI.Tests/JSONAPI.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Core\ResourceTypeRegistryTests.cs" />
     <Compile Include="Extensions\TypeExtensionsTests.cs" />
     <Compile Include="Http\BaseUrlServiceTest.cs" />
+    <Compile Include="Http\DefaultIncludeExpressionExtractorTests.cs" />
     <Compile Include="Http\DefaultSortExpressionExtractorTests.cs" />
     <Compile Include="Json\JsonApiFormatterTests.cs" />
     <Compile Include="Models\Author.cs" />

--- a/JSONAPI/Http/DefaultIncludeExpressionExtractor.cs
+++ b/JSONAPI/Http/DefaultIncludeExpressionExtractor.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using System.Net.Http;
+
+namespace JSONAPI.Http
+{
+    /// <summary>
+    /// Default implementation of <see cref="IIncludeExpressionExtractor" />
+    /// </summary>
+    public class DefaultIncludeExpressionExtractor: IIncludeExpressionExtractor
+    {
+        private const string IncludeQueryParamKey = "include";
+
+        public string[] ExtractIncludeExpressions(HttpRequestMessage requestMessage)
+        {
+            var queryParams = requestMessage.GetQueryNameValuePairs();
+            var includeParam = queryParams.FirstOrDefault(kvp => kvp.Key == IncludeQueryParamKey);
+            if (includeParam.Key != IncludeQueryParamKey) return new string[] { };
+            return includeParam.Value.Split(',');
+        }
+    }
+}

--- a/JSONAPI/Http/IIncludeExpressionExtractor.cs
+++ b/JSONAPI/Http/IIncludeExpressionExtractor.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http;
+
+namespace JSONAPI.Http
+{
+    /// <summary>
+    /// Service to extract include expressions from an HTTP request
+    /// </summary>
+    public interface IIncludeExpressionExtractor
+    {
+        /// <summary>
+        /// Extracts include expressions from the request
+        /// </summary>
+        /// <param name="requestMessage"></param>
+        /// <returns></returns>
+        string[] ExtractIncludeExpressions(HttpRequestMessage requestMessage);
+    }
+}

--- a/JSONAPI/Http/JsonApiController.cs
+++ b/JSONAPI/Http/JsonApiController.cs
@@ -63,7 +63,7 @@ namespace JSONAPI.Http
         }
 
         /// <summary>
-        /// Updates the record with the given ID with data from the request payloaad.
+        /// Updates the record with the given ID with data from the request payload.
         /// </summary>
         public virtual async Task<IHttpActionResult> Patch(string resourceType, string id, [FromBody]ISingleResourceDocument requestDocument, CancellationToken cancellationToken)
         {

--- a/JSONAPI/Http/QueryableToManyRelatedResourceDocumentMaterializer.cs
+++ b/JSONAPI/Http/QueryableToManyRelatedResourceDocumentMaterializer.cs
@@ -15,42 +15,42 @@ namespace JSONAPI.Http
     {
         private readonly IQueryableResourceCollectionDocumentBuilder _queryableResourceCollectionDocumentBuilder;
         private readonly ISortExpressionExtractor _sortExpressionExtractor;
+        private readonly IIncludeExpressionExtractor _includeExpressionExtractor;
+        /// <summary>
+        /// List of includes given by url.
+        /// </summary>
+        protected string[] Includes = {};
 
         /// <summary>
         /// Creates a new QueryableRelatedResourceDocumentMaterializer
         /// </summary>
         protected QueryableToManyRelatedResourceDocumentMaterializer(
             IQueryableResourceCollectionDocumentBuilder queryableResourceCollectionDocumentBuilder,
-            ISortExpressionExtractor sortExpressionExtractor)
+            ISortExpressionExtractor sortExpressionExtractor,
+            IIncludeExpressionExtractor includeExpressionExtractor)
         {
             _queryableResourceCollectionDocumentBuilder = queryableResourceCollectionDocumentBuilder;
             _sortExpressionExtractor = sortExpressionExtractor;
+            _includeExpressionExtractor = includeExpressionExtractor;
         }
 
         public async Task<IJsonApiDocument> GetRelatedResourceDocument(string primaryResourceId, HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            Includes = _includeExpressionExtractor.ExtractIncludeExpressions(request);
             var query = await GetRelatedQuery(primaryResourceId, cancellationToken);
-            var includes = GetIncludePaths();
             var sortExpressions = _sortExpressionExtractor.ExtractSortExpressions(request);
             if (sortExpressions == null || sortExpressions.Length < 1)
                 sortExpressions = GetDefaultSortExpressions();
-            return await _queryableResourceCollectionDocumentBuilder.BuildDocument(query, request, sortExpressions, cancellationToken, includes); // TODO: allow implementors to specify metadata
+
+
+            return await _queryableResourceCollectionDocumentBuilder.BuildDocument(query, request, sortExpressions, cancellationToken, Includes); // TODO: allow implementors to specify metadata
         }
 
         /// <summary>
         /// Gets the query for the related resources
         /// </summary>
         protected abstract Task<IQueryable<TRelated>> GetRelatedQuery(string primaryResourceId, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Gets a list of relationship paths to include
-        /// </summary>
-        /// <returns></returns>
-        protected virtual string[] GetIncludePaths()
-        {
-            return null;
-        }
 
         /// <summary>
         /// If the client doesn't request any sort expressions, these expressions will be used for sorting instead.

--- a/JSONAPI/JSONAPI.csproj
+++ b/JSONAPI/JSONAPI.csproj
@@ -90,10 +90,12 @@
     <Compile Include="Core\ResourceTypeRelationship.cs" />
     <Compile Include="Core\ToManyResourceTypeRelationship.cs" />
     <Compile Include="Core\ToOneResourceTypeRelationship.cs" />
+    <Compile Include="Http\DefaultIncludeExpressionExtractor.cs" />
     <Compile Include="Http\DefaultSortExpressionExtractor.cs" />
     <Compile Include="Http\DocumentMaterializerLocator.cs" />
     <Compile Include="Http\IDocumentMaterializerLocator.cs" />
     <Compile Include="Http\IRelatedResourceDocumentMaterializer.cs" />
+    <Compile Include="Http\IIncludeExpressionExtractor.cs" />
     <Compile Include="Http\ISortExpressionExtractor.cs" />
     <Compile Include="Http\MappedDocumentMaterializer.cs" />
     <Compile Include="Http\QueryableToManyRelatedResourceDocumentMaterializer.cs" />


### PR DESCRIPTION
- added basic IncludeExpressionExractor and introduced includes on EFDocumentMaterializer
- added includes to FallbackDocumentBuilder
- added tests for DefaultIncludeExpressionExtractor / fixed ugly typo
- added includes in ToManyRelatedResourceDocument
- removed obsolete method
- includes on create and update
- reverse deletion of GetDefaultSortExpressions
- fixed typo
- removed related to one and related to many methods from EntityFrameworkDocumentMaterializer because they are never used and replaced with EntityFrameworkToManyRelatedResourceDocumentMaterializer and EntityFrameworkToOneRelatedResourceDocumentMaterializer
- a try for the GetIncludes method (renamed to GetNavigationPropertiesIncludes)
- GetNavigationPropertiesIncludes added in EntityFrameworkToManyRelatedResourceDocumentMaterializer
- bring back get default sort expression
